### PR TITLE
Enable force update in AppWidgetHostPreview

### DIFF
--- a/appwidget-host/README.md
+++ b/appwidget-host/README.md
@@ -7,6 +7,10 @@ with Compose and [Live Edits](https://developer.android.com/jetpack/compose/tool
 enables, [in most situations](https://developer.android.com/studio/run#limitations), a real-time
 update mechanism, reflecting code changes nearly instantaneously.
 
+> Currently there is an issue that Live Edit stops working after the first change. It actually
+> updates the code but it does not render the update. To workaround you can click on the
+> AppWidgetHost container to force the update.
+
 > Note: This library is used by the appwidget-viewer and appwidget-configuration modules and is
 > independent from Glance-appwidget but provides extensions when glance-appwidget dependency is
 > present in the project

--- a/appwidget-host/src/main/java/com/google/android/glance/appwidget/host/AppWidgetHostPreview.kt
+++ b/appwidget-host/src/main/java/com/google/android/glance/appwidget/host/AppWidgetHostPreview.kt
@@ -19,15 +19,20 @@ package com.google.android.glance.appwidget.host
 import android.appwidget.AppWidgetProviderInfo
 import android.content.Context
 import android.widget.RemoteViews
+import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.DpSize
+import kotlinx.coroutines.launch
 
 /**
  * Use this composable inside a [androidx.compose.ui.tooling.preview.Preview] composable to
  * display previews of RemoteViews (e.g using GlanceRemoteViews from Glance-appwidget)
+ *
+ * Tip: Click on the container to force a content update.
  *
  * @param modifier defines the container box for the host
  * @param displaySize the available size for the RemoteViews, if not provider it will match parent
@@ -43,11 +48,27 @@ fun AppWidgetHostPreview(
     content: suspend (Context) -> RemoteViews
 ) {
     val hostState = rememberAppWidgetHostState(provider)
+    val scope = rememberCoroutineScope()
     val context = LocalContext.current
+
+    suspend fun updateContent() {
+        hostState.updateAppWidget(content(context))
+    }
+
     if (hostState.isReady) {
         LaunchedEffect(hostState.value) {
-            hostState.updateAppWidget(content(context))
+            updateContent()
         }
     }
-    AppWidgetHost(modifier, displaySize, hostState)
+    AppWidgetHost(
+        modifier = Modifier
+            .clickable {
+                scope.launch {
+                    updateContent()
+                }
+            }
+            .then(modifier),
+        displaySize = displaySize,
+        state = hostState
+    )
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -32,7 +32,7 @@ systemProp.org.gradle.internal.publish.checksums.insecure=true
 systemProp.org.gradle.internal.http.socketTimeout=120000
 
 GROUP=com.google.android.glance.tools
-VERSION_NAME=0.2.0
+VERSION_NAME=0.2.1
 
 POM_DESCRIPTION=Experimental tools for Jetpack Glance
 


### PR DESCRIPTION
Besides being a useful feature it will work as a workaround for the LiveEdit issue.
