### PR TITLE
Add a note indicating that corner radius will not show up in screensh…

### DIFF
--- a/appwidget-testing/README.md
+++ b/appwidget-testing/README.md
@@ -47,6 +47,10 @@ Then, using screenshot testing tool of your choice capture and compare the scree
 activity. For example, following sample uses [Roborazzi](https://github.com/takahirom/roborazzi)
 capture and verify the screenshot.
 
+NOTE: The device and screenshot framework you use should support hardware acceleration and
+`clipToOutline` to see rounded corners. For robolectric, see this
+[issue](https://github.com/robolectric/robolectric/issues/8081#issuecomment-1478137890)
+
 ```kotlin
 Espresso.onView(ViewMatchers.isRoot())
     .captureRoboImage(

--- a/appwidget-testing/src/main/java/com/google/android/glance/appwidget/testing/GlanceScreenshotTestActivity.kt
+++ b/appwidget-testing/src/main/java/com/google/android/glance/appwidget/testing/GlanceScreenshotTestActivity.kt
@@ -41,6 +41,10 @@ import kotlinx.coroutines.runBlocking
  * screenshot tests.
  *
  * See README.md for usage.
+ *
+ * NOTE: The device and screenshot framework you use should support hardware acceleration and
+ * `clipToOutline` to see rounded corners. For robolectric, see
+ * https://github.com/robolectric/robolectric/issues/8081#issuecomment-1478137890
  */
 @RequiresApi(Build.VERSION_CODES.O)
 public class GlanceScreenshotTestActivity : Activity() {

--- a/sample/src/test/java/com/google/android/glance/tools/testing/SampleGlanceScreenshotTest.kt
+++ b/sample/src/test/java/com/google/android/glance/tools/testing/SampleGlanceScreenshotTest.kt
@@ -48,6 +48,9 @@ class SampleGlanceScreenshotTest {
     fun sampleGlanceContent() {
         renderComposable()
 
+        // NOTE: The device and screenshot framework you use should support hardware acceleration
+        // and `clipToOutline` to see rounded corners. For robolectric, see this
+        //[issue](https://github.com/robolectric/robolectric/issues/8081#issuecomment-1478137890).
         captureAndVerifyScreenshot("sample_content")
     }
 


### PR DESCRIPTION
Add a note indicating that corner radius will not show up in screenshots if hardware acceleration / clipToOutline is not supported (it may depend on rendering framework / screenshot framework). With robolectric+roborazzi, it doesn't seem to work currently (remoteviews use clipToOutline). However, one can use a emulator and take screenshot with hardware bitmap if they'd like corner radius to appear).