### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/build-snapshot.yml
+++ b/.github/workflows/build-snapshot.yml
@@ -126,7 +126,7 @@ jobs:
           if [ "$API_LEVEL" -ge "28" ]; then
             TARGET="google_apis"
           fi
-          echo "::set-output name=TARGET::$TARGET"
+          echo "TARGET=$TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -126,7 +126,7 @@ jobs:
           if [ "$API_LEVEL" -ge "28" ]; then
             TARGET="google_apis"
           fi
-          echo "::set-output name=TARGET::$TARGET"
+          echo "TARGET=$TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Run tests
         uses: reactivecircus/android-emulator-runner@v2

--- a/.github/workflows/device-tests.yml
+++ b/.github/workflows/device-tests.yml
@@ -59,7 +59,7 @@ jobs:
           if [ "$API_LEVEL" -ge "29" ]; then
             TARGET="google_apis"
           fi
-          echo "::set-output name=TARGET::$TARGET"
+          echo "TARGET=$TARGET" >> "$GITHUB_OUTPUT"
 
       - name: Run device tests
         uses: reactivecircus/android-emulator-runner@v2


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter